### PR TITLE
Delete elements from context once we parsed them.

### DIFF
--- a/sitemap/urlset.py
+++ b/sitemap/urlset.py
@@ -1,4 +1,3 @@
-
 from lxml import etree
 from cStringIO import StringIO
 from urllib import urlopen
@@ -84,6 +83,8 @@ class UrlSet(object):
                     continue
             elif tag in ['loc', 'lastmod', 'changefreq', 'priority']:
                 element_data[tag] = elem.text
+            while elem.getprevious() is not None:
+                del elem.getparent()[0]
         del context
         del schema
 


### PR DESCRIPTION
I noticed that memory usage seemed to grow linearly with the size of the XML source being processed. 

This patch will free elements from memory as soon as they have are processed in get_urls_from_handle(). 

Ref: https://www.ibm.com/developerworks/xml/library/x-hiperfparse/
