### PR TITLE
iso8601: FixedOffset objects can not be unpickled

### DIFF
--- a/sitemap/iso8601.py
+++ b/sitemap/iso8601.py
@@ -43,7 +43,7 @@ class FixedOffset(tzinfo):
     """Fixed offset in hours and minutes from UTC
     
     """
-    def __init__(self, offset_hours, offset_minutes, name):
+    def set(self, offset_hours, offset_minutes, name):
         self.__offset = timedelta(hours=offset_hours, minutes=offset_minutes)
         self.__name = name
 
@@ -76,7 +76,9 @@ def parse_timezone(tzstring, default_timezone=UTC):
     if prefix == "-":
         hours = -hours
         minutes = -minutes
-    return FixedOffset(hours, minutes, tzstring)
+    offset = FixedOffset()
+    offset.set(hours, minutes, tzstring)
+    return offset
 
 def parse_date(datestring, default_timezone=UTC):
     """Parses ISO 8601 dates into datetime objects


### PR DESCRIPTION
This patch replaces the **init** of FixedOffset with a set method
instead. This is so we can unpickle datetime objects using this tzinfo
based class as a tzinfo= argument. you can read all about it at
https://docs.python.org/2/library/datetime.html#tzinfo-objects

I ran into this while trying to unpickle a pickled dictionary filled with
UrlSetElement objects that I had read in from the sitemap library which
had a lastmod set in the parsed sitemap you get a nasty traceback
complaining about **init** requiring 4 arguments but only one given with
out much useful info on what inside the pickle file caused it.
